### PR TITLE
주말 활용 대규모 업데이트

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,3 +132,15 @@ model Transfer{
 
   @@map("Transfer")
 }
+
+model Champion {
+  ChampionId Int @id @default(autoincrement())
+  Season Int
+  clubName String
+  win Int
+  lose Int
+  winRate Float
+  MMR Int
+
+  @@map("Champion")
+}

--- a/src/routes/gameplay.route.js
+++ b/src/routes/gameplay.route.js
@@ -4,6 +4,12 @@ import au from '../middlewares/auths/user-auth.middleware.js';
 
 const router = express.Router();
 
+// MMR 변화 폭 기준 설정
+const mmrrange = 100; // 최성원 추가 (ELO 방식으로 변경)
+
+// 시즌 우승 기준 MMR 설정
+const championMMR = 1200; // 최성원 추가 (시즌제 추가)
+
 // 게임플레이 API
 router.post('/gameplay', au, async (req, res, next) => {
   const { lineUp } = req.body;
@@ -27,62 +33,172 @@ router.post('/gameplay', au, async (req, res, next) => {
 
     const userTotalStat = userFormation.teamTotalStat;
 
-    // 상대 유저 랜덤 선택
-    const opponent = await prisma.users.findMany({ where: { NOT: { userId: req.user.userId } } });
-    const randomOpponent = opponent[Math.floor(Math.random() * opponent.length)];
+    //## 최성원 삭제 (전체 랜덤 → 점수 가까운 순으로 바꾸기 위함)
+    // // 상대 유저 랜덤 선택
+    // const opponent = await prisma.users.findMany({ where: { NOT: { userId: req.user.userId } } });
+    // const randomOpponent = opponent[Math.floor(Math.random() * opponent.length)];
 
-    // 상대 포메이션 조회
-    const opponentFormations = await prisma.formations.findMany({
-      where: { userId: randomOpponent.userId },
+    // // 상대 포메이션 조회
+    // const opponentFormations = await prisma.formations.findMany({
+    //   where: { userId: randomOpponent.userId },
+    // });
+
+    // if (opponentFormations.length === 0) {
+    //   return res.status(404).json({ message: '상대 포메이션을 찾을 수 없습니다.' });
+    // }
+    //## 최성원 삭제 (전체 랜덤 → 점수 가까운 순으로 바꾸기 위함)
+
+    //## 최성원 추가 (전체 랜덤 → 점수 가까운 순으로 바꾸기 위함)
+    // 우리 클럽
+    const myclub = await prisma.club.findFirst({
+      where: { userId: req.user.userId },
     });
 
-    if (opponentFormations.length === 0) {
-      return res.status(404).json({ message: '상대 포메이션을 찾을 수 없습니다.' });
-    }
+    // 상대 클럽 전체
+    const opponents = await prisma.club.findMany({
+      where: { NOT: { userId: req.user.userId } },
+    });
 
-    // 랜덤하게 상대 포메이션 선택
-    const opponentFormation =
-      opponentFormations[Math.floor(Math.random() * opponentFormations.length)];
+    // 상대 클럽 전체를 우리클럽과 MMR격차가 작은 순서로 정렬
+    const MMRopponents = opponents.sort(
+      (a, b) => Math.abs(myclub.MMR - a.MMR) - Math.abs(myclub.MMR - b.MMR),
+    );
+
+    // 정렬된 순서대로 보유한 Formation이 있는 상대 탐색
+    let opponentFormation;
+    for (let opponent of MMRopponents) {
+      opponentFormation = await prisma.formations.findFirst({
+        where: { userId: opponent.userId },
+      });
+      if (opponentFormation) {
+        break;
+      }
+    }
+    //## 최성원 추가 (전체 랜덤 → 점수 가까운 순으로 바꾸기 위함)
+
+    //## 최성원 삭제 (전체 랜덤 → 점수 가까운 순으로 바꾸기 위함)
+    // // 랜덤하게 상대 포메이션 선택
+    // const opponentFormation =
+    //   opponentFormations[Math.floor(Math.random() * opponentFormations.length)];
+    //## 최성원 삭제 (전체 랜덤 → 점수 가까운 순으로 바꾸기 위함)
+
+    //## 최성원 추가 (유효성 검사)
+    if (!opponentFormation) {
+      return res
+        .status(404)
+        .json({ Message: `게임 내에 포메이션이 준비된 유저가 존재하지 않습니다.` });
+    }
+    //## 최성원 추가 (유효성 검사)
+
     const opponentTotalStat = opponentFormation.teamTotalStat;
 
-    // 점수 계산
-    const userScore = Math.floor(Math.random() * 5) + 1; // 1에서 5 사이의 랜덤 점수
-    const opponentScore = Math.floor(Math.random() * 5) + 1; // 1에서 5 사이의 랜덤 점수
+    // 스탯에 따른 점수 계산
+    const statDifference = userTotalStat - opponentTotalStat;
+    const baseScore = Math.floor(Math.random() * 3) + 1; // 기본 점수는 1~3
+    let userScore = baseScore;
+    let opponentScore = baseScore;
+
+    // 스탯 차이로 인한 점수 증가
+    if (statDifference > 0) {
+      // 스탯 차이가 10 이상 일 때 내 점수 추가
+      userScore += Math.floor(statDifference / 10);
+    } else {
+      // 상대방의 스탯이 높을 경우 상대 점수 증가
+      opponentScore += Math.floor(-statDifference / 10);
+    }
+
+    // 최종 점수는 최소 1점에서 최대 5점으로 제한
+    userScore = Math.min(Math.max(userScore, 1), 5);
+    opponentScore = Math.min(Math.max(opponentScore, 1), 5);
+
+    // 동점 방지 (동점일 경우 점수 조정)
+    if (userScore === opponentScore) {
+      if (Math.random() > 0.5) {
+        userScore++; // 내 점수 증가
+      } else {
+        opponentScore++; // 상대방 점수 증가
+      }
+
+      //## 최성원 삭제 (불가능한 상황: 4:3이 최대)
+      // // 최종 점수는 여전히 5점을 넘지 않도록 제한
+      // userScore = Math.min(userScore, 5);
+      // opponentScore = Math.min(opponentScore, 5);
+      //## 최성원 삭제 (불가능한 상황: 4:3이 최대)
+    }
 
     let result;
-    let mmrChange = 10; // 기본 MMR 변화량
+    // let mmrChange = 10; // 기본 MMR 변화량 //////최성원 삭제 (ELO 방식으로 변경)
     const userClub = await prisma.club.findUnique({ where: { userId: req.user.userId } });
-    const opponentClub = await prisma.club.findUnique({ where: { userId: randomOpponent.userId } });
+    const opponentClub = await prisma.club.findUnique({
+      where: { userId: opponentFormation.userId },
+    });
 
     let earnedGold, mmrChangeAmount;
 
+    const mmrdifference = (opponentClub.MMR - userClub.MMR) / 400; //////최성원 추가 (ELO 방식으로 변경)
+    const predictedwinrate = 1 / (10 ** mmrdifference + 1); //////최성원 추가 (ELO 방식으로 변경)
     if (userScore > opponentScore) {
-      result = `${userClub.clubName}님이 승리하였습니다! ${userScore} - ${opponentScore}`;
+      result = `${userClub.clubName}님이 승리하였습니다! 스코어 ${userScore} - ${opponentScore} 로 이겼습니다!`;
       earnedGold = 10000;
-      mmrChangeAmount = userClub.win > 0 ? mmrChange + 5 : mmrChange;
+      mmrChangeAmount = Math.ceil(mmrrange * (1 - predictedwinrate)); //////최성원 수정 (ELO 방식으로 변경)
 
       await prisma.club.update({
         where: { userId: req.user.userId },
         data: {
           win: { increment: 1 },
           gold: { increment: earnedGold },
-          MMR: { increment: mmrChangeAmount },
+          MMR: { increment: mmrChangeAmount }, //////최성원 수정 (ELO 방식으로 변경)
         },
       });
       await prisma.club.update({
-        where: { userId: randomOpponent.userId },
+        where: { userId: opponentClub.userId }, //////최성원 수정 (ELO 방식으로 변경)
         data: {
           lose: { increment: 1 },
           gold: { increment: 5000 },
-          MMR: { decrement: opponentClub.lose > 0 ? mmrChange + 5 : mmrChange },
+          MMR: { decrement: mmrChangeAmount }, //////최성원 수정 (ELO 방식으로 변경)
         },
       });
 
+      //## 최성원 추가 (시즌제 기능 추가 / MMR 기준)
+      if (userClub.MMR + mmrChangeAmount > championMMR) {
+        const champions = await prisma.champion.findMany({});
+        let prevseason = 0;
+        for (let champion of champions) {
+          prevseason = Math.max(prevseason, champion.Season);
+        }
+
+        await prisma.champion.create({
+          data: {
+            Season: prevseason + 1,
+            clubName: userClub.clubName,
+            win: userClub.win + 1,
+            lose: userClub.lose,
+            winRate: (userClub.win + 1) / (1 + userClub.win + userClub.lose),
+            MMR: userClub.MMR + mmrChangeAmount,
+          },
+        });
+
+        const Resetclubs = await prisma.club.findMany({});
+        for (let Resetclub of Resetclubs) {
+          await prisma.club.update({
+            where: { clubId: Resetclub.clubId },
+            data: {
+              win: 0,
+              lose: 0,
+              MMR: 1000,
+            },
+          });
+        }
+
+        result += ` ${userClub.clubName}님이 ${prevseason + 1}시즌 챔피언을 차지하였습니다!`;
+      }
+      //## 최성원 추가 (시즌제 기능 추가 / MMR 기준)
+
       result += ` ${earnedGold} 골드를 획득하였습니다! MMR이 ${mmrChangeAmount} 상승하였습니다!`;
     } else {
-      result = `${opponentClub.clubName}님이 승리하였습니다! ${userScore} - ${opponentScore}`;
+      result = `${opponentClub.clubName}님이 승리하였습니다! 스코어 ${userScore} - ${opponentScore} 로 이겼습니다!`;
       earnedGold = 5000;
-      mmrChangeAmount = userClub.lose > 0 ? mmrChange + 5 : mmrChange;
+      mmrChangeAmount = Math.ceil(mmrrange * predictedwinrate); //////최성원 수정 (ELO 방식으로 변경)
 
       await prisma.club.update({
         where: { userId: req.user.userId },
@@ -93,13 +209,48 @@ router.post('/gameplay', au, async (req, res, next) => {
         },
       });
       await prisma.club.update({
-        where: { userId: randomOpponent.userId },
+        where: { userId: opponentClub.userId }, //////최성원 수정 (ELO 방식으로 변경)
         data: {
           win: { increment: 1 },
           gold: { increment: 10000 },
-          MMR: { increment: opponentClub.win > 0 ? mmrChange + 5 : mmrChange },
+          MMR: { increment: mmrChangeAmount }, //////최성원 수정 (ELO 방식으로 변경)
         },
       });
+
+      //## 최성원 추가 (시즌제 기능 추가 / MMR 기준)
+      if (opponentClub.MMR + mmrChangeAmount > championMMR) {
+        const champions = await prisma.champion.findMany({});
+        let prevseason = 0;
+        for (let champion of champions) {
+          prevseason = Math.max(prevseason, champion.Season);
+        }
+
+        await prisma.champion.create({
+          data: {
+            Season: prevseason + 1,
+            clubName: opponentClub.clubName,
+            win: opponentClub.win + 1,
+            lose: opponentClub.lose,
+            winRate: (opponentClub.win + 1) / (1 + opponentClub.win + opponentClub.lose),
+            MMR: opponentClub.MMR + mmrChangeAmount,
+          },
+        });
+
+        const Resetclubs = await prisma.club.findMany({});
+        for (let Resetclub of Resetclubs) {
+          await prisma.club.update({
+            where: { clubId: Resetclub.clubId },
+            data: {
+              win: 0,
+              lose: 0,
+              MMR: 1000,
+            },
+          });
+        }
+
+        result += ` ${opponentClub.clubName}님이 ${prevseason + 1}시즌 챔피언을 차지하였습니다!`;
+      }
+      //## 최성원 추가 (시즌제 기능 추가 / MMR 기준)
 
       result += ` ${earnedGold} 골드를 획득하였습니다. MMR이 ${mmrChangeAmount} 감소하였습니다.`;
     }
@@ -108,37 +259,6 @@ router.post('/gameplay', au, async (req, res, next) => {
       message: result,
       opponent: opponentClub.clubName,
     });
-  } catch (error) {
-    next(error);
-  }
-});
-
-// 클럽 랭킹 정보
-router.get('/rankings', async (req, res, next) => {
-  try {
-    const rankings = await prisma.club.findMany({
-      select: {
-        clubName: true,
-        MMR: true,
-        win: true,
-        lose: true,
-      },
-      orderBy: {
-        MMR: 'desc',
-      },
-    });
-
-    if (rankings.length === 0) {
-      return res.status(404).json({ message: '랭킹 정보를 찾을 수 없습니다.' });
-    }
-
-    // 순위 추가
-    const rankingsWithRank = rankings.map((club, index) => ({
-      rank: index + 1,
-      ...club,
-    }));
-
-    return res.status(200).json(rankingsWithRank);
   } catch (error) {
     next(error);
   }

--- a/src/routes/shop.route.js
+++ b/src/routes/shop.route.js
@@ -1,29 +1,43 @@
 import express from 'express';
 import { prisma } from '../lib/utils/prisma/index.js';
 import au from '../middlewares/auths/user-auth.middleware.js';
+
 const router = express.Router();
+
 // 선수카드 가격 (골드)
 const goldprice = 1000;
+
 // 감독카드 가격 (캐시)
 const cashprice = 1000;
+
 // 캐시 충전량 제한 (최소)
 const mincash = 1000;
+
 // 캐시 충전량 제한 (최대)
 const maxcash = 1000000;
+
 // 카드 랜덤 뽑기
 router.post('/shop/gacha', au, async (req, res, next) => {
   try {
     const { type, count } = req.body;
+
     const club = await prisma.club.findFirst({
       where: { userId: req.user.userId },
     });
+
     // 유효성 검사
+    if (!club) {
+      return res.status(404).json({ Message: '클럽을 먼저 생성해 주세요.' });
+    }
+
     if (type !== 'player' && type !== 'manager') {
       return res.status(400).json({ message: '올바른 카드타입(player, manager)을 입력하세요.' });
     }
+
     if (isNaN(count) || count <= 0) {
       return res.status(400).json({ message: '개수(count)는 1 이상의 숫자를 입력하세요.' });
     }
+
     // 준비된 카드 모델 존재 여부 검사
     const allCards = await prisma.cardModel.findMany({
       where: { type },
@@ -31,7 +45,22 @@ router.post('/shop/gacha', au, async (req, res, next) => {
     if (allCards.length === 0) {
       return res.status(503).json({ message: `아직 ${type} 카드 모델을 준비중입니다.` });
     }
+
+    // 재화 부족 여부 검사
+    if (type === 'player' && goldprice * count > club.gold) {
+      return res
+        .status(400)
+        .json({ message: `골드가 ${goldprice * count - club.gold}원만큼 부족합니다.` });
+    }
+
+    if (type === 'manager' && cashprice * count > club.cash) {
+      return res
+        .status(400)
+        .json({ message: `캐시가 ${cashprice * count - club.cash}원만큼 부족합니다.` });
+    }
+
     const cards = [];
+
     // 카드 생성 및 골드/캐시 차감
     await prisma.$transaction(async (tx) => {
       // 카드 번호 설정
@@ -41,6 +70,7 @@ router.post('/shop/gacha', au, async (req, res, next) => {
         take: 1,
       });
       const nextCardNumber = existingCards.length > 0 ? existingCards[0].cardNumber + 1 : 1;
+
       // 카드 생성
       for (let i = 0; i < count; i++) {
         const randomN = Math.floor(Math.random() * allCards.length);
@@ -57,7 +87,7 @@ router.post('/shop/gacha', au, async (req, res, next) => {
             defense: selectedCard.defense,
             stamina: selectedCard.stamina,
             cardNumber: nextCardNumber + i, // 각 카드에 대한 번호 설정
-            type: type
+            type: type,
           },
         });
         cards.push(card);
@@ -77,24 +107,33 @@ router.post('/shop/gacha', au, async (req, res, next) => {
     next(error);
   }
 });
+
 // 캐시 충전
 router.patch('/shop/recharge', au, async (req, res, next) => {
   try {
     const { cash } = req.body;
-    // 유효성 검사
-    if (isNaN(cash)) {
-      return res.status(400).json({ message: '캐시는 숫자를 입력해주세요.' });
-    }
-    // 캐시 충전 범위
-    if (cash < mincash || cash > maxcash) {
-      return res
-        .status(400)
-        .json({ message: `캐시는 한번에 최소 ${mincash}원 최대 ${maxcash/10000}만원까지 충전이 가능합니다.` });
-    }
-    // 충전
+
     const club = await prisma.club.findFirst({
       where: { userId: req.user.userId },
     });
+
+    // 유효성 검사
+    if (!club) {
+      return res.status(404).json({ Message: '클럽을 먼저 생성해 주세요.' });
+    }
+
+    if (isNaN(cash)) {
+      return res.status(400).json({ message: '캐시는 숫자를 입력해주세요.' });
+    }
+
+    // 캐시 충전 범위
+    if (cash < mincash || cash > maxcash) {
+      return res.status(400).json({
+        message: `캐시는 한번에 최소 ${mincash}원 최대 ${maxcash / 10000}만원까지 충전이 가능합니다.`,
+      });
+    }
+
+    // 충전
     await prisma.club.update({
       where: { clubId: club.clubId },
       data: {
@@ -106,4 +145,5 @@ router.patch('/shop/recharge', au, async (req, res, next) => {
     next(error);
   }
 });
+
 export default router;

--- a/src/routes/transfer.route.js
+++ b/src/routes/transfer.route.js
@@ -43,7 +43,7 @@ router.post('/transfer/sell', au, async (req, res, next) => {
       return res.status(404).json({ Message: '존재하지 않는 카드 아이디입니다.' });
     }
 
-    // 카드 소유권 여부 검사
+    // 카드 소유권 검사
     if (card.userId !== req.user.userId) {
       return res.status(403).json({ Message: '다른 유저의 카드를 등록할 수 없습니다.' });
     }
@@ -71,7 +71,10 @@ router.post('/transfer/sell', au, async (req, res, next) => {
     });
     const registeredcard = { ...transfercard, ...card };
 
-    return res.status(201).json({ registeredcard });
+    return res.status(201).json({
+      Message: `이적시장에 ${card.card_enhancement}강 ${card.cardName}카드가 등록되었습니다!`,
+      registeredcard,
+    });
   } catch (error) {
     next(error);
   }
@@ -98,7 +101,7 @@ router.patch('/transfer/purchase', au, async (req, res, next) => {
       where: { transferId: transferId },
     });
     if (!transfer) {
-      return res.status(404).json({ Message: '존재하지 않는 이적시장 아이디입니다..' });
+      return res.status(404).json({ Message: '존재하지 않는 이적시장 아이디입니다.' });
     }
 
     // 자신이 등록한 카드를 구매하려할 경우
@@ -117,6 +120,14 @@ router.patch('/transfer/purchase', au, async (req, res, next) => {
     const sellclub = await prisma.club.findFirst({
       where: { userId: card.userId },
     });
+
+    // 다음 카드 번호
+    const existingCards = await prisma.cards.findMany({
+      where: { userId: club.userId },
+      orderBy: { cardNumber: 'desc' },
+      take: 1,
+    });
+    const nextCardNumber = existingCards.length > 0 ? existingCards[0].cardNumber + 1 : 1;
 
     // 카드 구매
     await prisma.$transaction(async (tx) => {
@@ -139,7 +150,7 @@ router.patch('/transfer/purchase', au, async (req, res, next) => {
         data: {
           userId: req.user.userId,
           clubId: club.clubId,
-          cardNumber: 1,
+          cardNumber: nextCardNumber,
           state: 'inventory',
         },
       });
@@ -149,7 +160,10 @@ router.patch('/transfer/purchase', au, async (req, res, next) => {
       });
     });
 
-    return res.status(201).json({ card });
+    return res.status(201).json({
+      Messaeg: `이적시장에서 ${card.card_enhancement}강 ${card.cardName}카드를 구매하였습니다!`,
+      card,
+    });
   } catch (error) {
     next(error);
   }
@@ -158,15 +172,23 @@ router.patch('/transfer/purchase', au, async (req, res, next) => {
 // 이적시장 조회
 router.get('/transfer', au, async (req, res, next) => {
   try {
+    const { min, max } = req.body;
+
     // 클럽 존재 여부 검사
     const club = await prisma.club.findFirst({
       where: { userId: req.user.userId },
     });
     if (!club) {
-      return res.status(404).json({ Message: '클럽을 먼저 생성해 주세요.' });
+      return res.status(404).json({ Message: '클럽이 있어야 이적시장을 둘러볼 수 있습니다.' });
     }
 
     const transferCard = await prisma.transfer.findMany({
+      where: {
+        price: {
+          gte: min,
+          lte: max,
+        },
+      },
       include: {
         cards: {
           select: {
@@ -184,6 +206,63 @@ router.get('/transfer', au, async (req, res, next) => {
     });
 
     return res.status(201).json({ transferCard });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// 이적시장 판매 등록 취소
+router.delete('/transfer/sell', au, async (req, res, next) => {
+  try {
+    const { transferId } = req.body;
+
+    // club 존재 여부
+    const club = await prisma.club.findFirst({
+      where: { userId: req.user.userId },
+    });
+    if (!club) {
+      return res.status(404).json({ Message: '클럽을 먼저 생성해 주세요.' });
+    }
+
+    // 이적시장 아이디 유효성 검사
+    if (isNaN(transferId)) {
+      return res
+        .status(400)
+        .json({ Message: '올바른 형식의 이적시장 아이디를 입력하세요. (숫자를 입력해주세요)' });
+    }
+    const transfer = await prisma.transfer.findFirst({
+      where: { transferId: transferId },
+    });
+    if (!transfer) {
+      return res.status(400).json({ Message: '존재하지 않는 이적시장 아이디 입니다.' });
+    }
+
+    // 카드 소유권 여부 검사
+    const card = await prisma.cards.findFirst({
+      where: { cardId: transfer.cardId },
+    });
+
+    if (card.userId !== req.user.userId) {
+      return res.status(403).json({ Message: '다른 유저의 카드를 등록취소할 수 없습니다.' });
+    }
+
+    // 이적시장에서 카드 등록 취소
+    await prisma.$transaction(async (tx) => {
+      await tx.cards.update({
+        where: { cardId: transfer.cardId },
+        data: { state: 'inventory' },
+      });
+
+      await tx.transfer.delete({
+        where: { transferId: transferId },
+      });
+    });
+    const registeredcard = { ...transfer, ...card };
+
+    return res.status(200).json({
+      Message: `이적시장에서 ${card.card_enhancement}강 ${card.cardName}카드의 등록이 취소되었습니다.`,
+      registeredcard,
+    });
   } catch (error) {
     next(error);
   }

--- a/src/routes/upgrade.route.js
+++ b/src/routes/upgrade.route.js
@@ -14,11 +14,115 @@ const upgrade_percentage_zero = 1;
 const upgrade_percentage_down = 0.1;
 
 // 선수 카드 강화
-router.post('/upgrading', au, async (req, res, next) => {
+router.post('/upgrading/one', au, async (req, res, next) => {
   try {
     const { cardId } = req.body;
 
-    // 유효성 검사
+    // 카드아이디 유효성 검사
+    if (isNaN(cardId)) {
+      return res
+        .status(400)
+        .json({ Message: '올바른 형식의 카드아이디를 입력하세요. (숫자를 입력해주세요)' });
+    }
+
+    const upgradecard = await prisma.cards.findFirst({
+      where: { cardId: cardId },
+    });
+    if (!upgradecard) {
+      return res.status(404).json({ Message: '존재하지 않는 카드아이디 입니다.' });
+    }
+
+    // 카드 인벤토리 여부 검사
+    if (upgradecard.state !== 'inventory') {
+      return res.status(400).json({
+        Message: '인벤토리에 있는 카드만 강화가 가능합니다. 장착을 해제하고 시도해주세요',
+      });
+    }
+
+    // 카드 소유권 검사
+    if (upgradecard.userId !== req.user.userId) {
+      return res.status(403).json({ Message: '다른 유저의 카드를 강화할 수 없슨니다.' });
+    }
+
+    // 재료 카드 존재 여부 검사
+    const materialcard = await prisma.cards.findFirst({
+      where: {
+        userId: req.user.userId,
+        cardCode: upgradecard.cardCode,
+        card_enhancement: upgradecard.card_enhancement,
+        state: 'inventory',
+        NOT: { cardId: cardId },
+      },
+    });
+    if (!materialcard) {
+      return res.status(404).json({
+        Message: '재료카드가 존재하지 않습니다. (강화 레벨과 카드종류가 동일한 카드가 필요합니다)',
+      });
+    }
+
+    // 강화 성공 확률
+    const percentage =
+      upgrade_percentage_zero - upgradecard.card_enhancement * upgrade_percentage_down;
+
+    // 능력치 기준 모델
+    const cardmodel = await prisma.cardModel.findFirst({
+      where: { cardCode: upgradecard.cardCode },
+    });
+
+    let result = '';
+    let upgradedcard;
+
+    // 강화 시도
+    await prisma.$transaction(async (tx) => {
+      // 재료카드 소진
+      await tx.cards.delete({
+        where: { cardId: materialcard.cardId },
+      });
+
+      // 강화 성공 시
+      if (Math.random() < percentage) {
+        upgradedcard = await tx.cards.update({
+          where: { cardId: upgradecard.cardId },
+          data: {
+            card_enhancement: upgradecard.card_enhancement + 1,
+            speed: upgradecard.speed + cardmodel.speed * upgrade_stat_up,
+            shoot_accuracy: upgradecard.shoot_accuracy + cardmodel.shoot_accuracy * upgrade_stat_up,
+            shoot_power: upgradecard.shoot_power + cardmodel.shoot_power * upgrade_stat_up,
+            defense: upgradecard.defense + cardmodel.defense * upgrade_stat_up,
+            stamina: upgradecard.stamina + cardmodel.stamina * upgrade_stat_up,
+          },
+        });
+
+        result += '강화에 성공하여 재료카드가 소진되었습니다';
+      } else {
+        result += '강화에 실패하여 재료카드만 소진되었습니다';
+      }
+    });
+
+    // cardNumber 정리: 병렬로 처리
+    const cardsort = await prisma.cards.findMany({
+      where: { userId: req.user.userId },
+    });
+
+    const sortpromise = cardsort.map((card, index) => {
+      return prisma.cards.update({
+        where: { cardId: card.cardId },
+        data: { cardNumber: index + 1 },
+      });
+    });
+    await Promise.all(sortpromise);
+
+    return res.status(201).json({ result, upgradedcard, materialcard });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// 선수 카드 다중 강화
+router.post('/upgrading/every', au, async (req, res, next) => {
+  try {
+    const { cardId } = req.body;
+
     // 카드아이디 형식 검사
     if (isNaN(cardId)) {
       return res
@@ -34,10 +138,10 @@ router.post('/upgrading', au, async (req, res, next) => {
       return res.status(404).json({ Message: '존재하지 않는 카드아이디 입니다.' });
     }
 
-    // 카드 장착 여부 검사
-    if (upgradecard.equipState) {
+    // 카드 인벤토리 여부 검사
+    if (upgradecard.state !== 'inventory') {
       return res.status(400).json({
-        Message: '포메이션에 장착중인 카드는 강화할 수 없습니다. 장착을 해제하고 시도해주세요',
+        Message: '인벤토리에 있는 카드만 강화가 가능합니다. 장착을 해제하고 시도해주세요',
       });
     }
 
@@ -47,56 +151,83 @@ router.post('/upgrading', au, async (req, res, next) => {
     }
 
     // 재료 카드 존재 여부 검사
-    const materialcard = await prisma.cards.findFirst({
+    const materialcards = await prisma.cards.findMany({
       where: {
+        userId: req.user.userId,
         cardCode: upgradecard.cardCode,
         card_enhancement: upgradecard.card_enhancement,
-        NOT: { cardId: cardId },
+        state: 'inventory',
       },
     });
-    if (!materialcard) {
+    if (materialcards.length < 2) {
       return res.status(404).json({
         Message: '재료카드가 존재하지 않습니다. (강화 레벨과 카드종류가 동일한 카드가 필요합니다)',
       });
     }
 
-    // 강화 성공/실패
+    // 강화 성공 확률
     const percentage =
       upgrade_percentage_zero - upgradecard.card_enhancement * upgrade_percentage_down;
+
+    // 능력치 기준 모델
     const cardmodel = await prisma.cardModel.findFirst({
       where: { cardCode: upgradecard.cardCode },
     });
-    if (Math.random() < percentage) {
-      const upgradedcard = await prisma.$transaction(async (tx) => {
-        const card = await tx.cards.update({
-          where: { cardId: upgradecard.cardId },
-          data: {
-            card_enhancement: upgradecard.card_enhancement + 1,
-            speed: upgradecard.speed + cardmodel.speed * upgrade_stat_up,
-            shoot_accuracy: upgradecard.shoot_accuracy + cardmodel.shoot_accuracy * upgrade_stat_up,
-            shoot_power: upgradecard.shoot_power + cardmodel.shoot_power * upgrade_stat_up,
-            defense: upgradecard.defense + cardmodel.defense * upgrade_stat_up,
-            stamina: upgradecard.stamina + cardmodel.stamina * upgrade_stat_up,
-          },
-        });
 
-        await tx.cards.delete({
-          where: { cardId: materialcard.cardId },
-        });
+    // 강화 시도 예정 횟수
+    const tryupgrade = Math.floor(materialcards.length / 2);
 
-        return card;
+    const upgradedcards = []; //res 용도
+    const deletedcards = []; //res 용도
+
+    // 강화 시도
+    await prisma.$transaction(async (tx) => {
+      for (let i = 0; i < tryupgrade; i++) {
+        // 재료카드 소진
+        const deletecards = await tx.cards.delete({
+          where: { cardId: materialcards[2 * i + 1].cardId },
+        });
+        deletedcards.push(deletecards);
+
+        // 강화 성공 시
+        if (Math.random() < percentage) {
+          const successcard = await tx.cards.update({
+            where: { cardId: materialcards[2 * i].cardId },
+            data: {
+              card_enhancement: materialcards[2 * i].card_enhancement + 1,
+              speed: materialcards[2 * i].speed + cardmodel.speed * upgrade_stat_up,
+              shoot_accuracy:
+                materialcards[2 * i].shoot_accuracy + cardmodel.shoot_accuracy * upgrade_stat_up,
+              shoot_power:
+                materialcards[2 * i].shoot_power + cardmodel.shoot_power * upgrade_stat_up,
+              defense: materialcards[2 * i].defense + cardmodel.defense * upgrade_stat_up,
+              stamina: materialcards[2 * i].stamina + cardmodel.stamina * upgrade_stat_up,
+            },
+          });
+
+          upgradedcards.push(successcard);
+        }
+      }
+    });
+
+    // cardNumber 정리: 병렬로 처리
+    const cardsort = await prisma.cards.findMany({
+      where: { userId: req.user.userId },
+    });
+
+    const sortpromise = cardsort.map((card, index) => {
+      return prisma.cards.update({
+        where: { cardId: card.cardId },
+        data: { cardNumber: index + 1 },
       });
+    });
+    await Promise.all(sortpromise);
 
-      return res.status(201).json({ upgradedcard });
-    } else {
-      await prisma.$transaction(async (tx) => {
-        await tx.cards.delete({
-          where: { cardId: materialcard.cardId },
-        });
-      });
-
-      return res.status(201).json({ Message: '강화에 실패하였습니다.' });
-    }
+    return res.status(201).json({
+      Message: `강화를 ${tryupgrade}회 시도하여 ${upgradedcards.length}회 성공하였습니다`,
+      upgradedcards,
+      deletedcards,
+    });
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
// upgrade
upgrade 실패시 res문구에 소진된 재료카드 추가
다중 업그레이드 기능 추가
cardNumber 정렬 추가 (병렬처리)


// transfer
equipstate -> state
구매 시 cardNumber 구현


// 시즌제 기능 추가
// schema model champion 추가


// game play
변경사항
1. mmr 계산방식을 elo 시스템으로 바꾸기
2. 점수가 비슷한 상대를 고르기
3. 포메이션이 없는 팀도 선택 → 포메이션 장착한 팀만 선택